### PR TITLE
configure: Install zsh completions where zsh will find them.

### DIFF
--- a/configure
+++ b/configure
@@ -1206,7 +1206,7 @@ desktop_dir = \$(prefix)/share/applications
 bash_completion_dir = ${BASHCOMPLETIONDIR:=\$(prefix)/share/bash-completion/completions}
 
 # The directory to which zsh completions files should be installed
-zsh_completion_dir = ${ZSHCOMLETIONDIR:=\$(prefix)/share/zsh/functions/Completion/Unix}
+zsh_completion_dir = ${ZSHCOMLETIONDIR:=\$(prefix)/share/zsh/site-functions}
 
 # Whether the canonicalize_file_name function is available (if not, then notmuch will
 # build its own version)


### PR DESCRIPTION
Zsh searches in the $fpath array for completion functions. By default
this includes $(prefix)/share/zsh/site-functions but not the existing
value. The prefix for zsh and notmuch isn't guaranteed to be the same
but it normally will be making this a better default for
zsh_completion_dir.

Zsh itself creates site-functions as an empty directory for this purpose. You may also see "vendor-completions" but this is only a Debian/Ubuntu convention where they wanted to leave site-functions for local system administrators so don't be tempted to use that.